### PR TITLE
Respect newlines and tabs in replacement string

### DIFF
--- a/api.js
+++ b/api.js
@@ -26,7 +26,7 @@ module.exports = async (filePaths, {find, replacement, ignoreCase} = {}) => {
 		throw new Error('The `replacement` option is required');
 	}
 
-	//Replace replacement string with string unescaped (with only one backslash) if it is escaped
+	// Replace replacement string with string unescaped (only one backslash) if it is escaped
 	replacement = replacement
 	.replace(/\\n/g, "\n")
 	.replace(/\\r/g, "\r")

--- a/api.js
+++ b/api.js
@@ -30,9 +30,7 @@ module.exports = async (filePaths, {find, replacement, ignoreCase} = {}) => {
 	replacement = replacement
 		.replace(/\\n/g, '\n')
 		.replace(/\\r/g, '\r')
-		.replace(/\\t/g, '\t')
-		.replace(/\\b/g, '\b')
-		.replace(/\\f/g, '\f');
+		.replace(/\\t/g, '\t');
 
 	// Deduplicate
 	filePaths = [...new Set(filePaths.map(filePath => path.resolve(filePath)))];

--- a/api.js
+++ b/api.js
@@ -26,6 +26,14 @@ module.exports = async (filePaths, {find, replacement, ignoreCase} = {}) => {
 		throw new Error('The `replacement` option is required');
 	}
 
+	//Replace replacement string with string unescaped (with only one backslash) if it is escaped
+	replacement = replacement
+	.replace(/\\n/g, "\n")
+	.replace(/\\r/g, "\r")
+	.replace(/\\t/g, "\t")
+	.replace(/\\b/g, "\b")
+	.replace(/\\f/g, "\f");
+
 	// Deduplicate
 	filePaths = [...new Set(filePaths.map(filePath => path.resolve(filePath)))];
 

--- a/api.js
+++ b/api.js
@@ -26,7 +26,7 @@ module.exports = async (filePaths, {find, replacement, ignoreCase} = {}) => {
 		throw new Error('The `replacement` option is required');
 	}
 
-	// Replace replacement string with string unescaped (only one backslash) if it is escaped
+	// Replace the replacement string with the string unescaped (only one backslash) if it's escaped
 	replacement = replacement
 		.replace(/\\n/g, '\n')
 		.replace(/\\r/g, '\r')

--- a/api.js
+++ b/api.js
@@ -28,11 +28,11 @@ module.exports = async (filePaths, {find, replacement, ignoreCase} = {}) => {
 
 	// Replace replacement string with string unescaped (only one backslash) if it is escaped
 	replacement = replacement
-	.replace(/\\n/g, "\n")
-	.replace(/\\r/g, "\r")
-	.replace(/\\t/g, "\t")
-	.replace(/\\b/g, "\b")
-	.replace(/\\f/g, "\f");
+		.replace(/\\n/g, '\n')
+		.replace(/\\r/g, '\r')
+		.replace(/\\t/g, '\t')
+		.replace(/\\b/g, '\b')
+		.replace(/\\f/g, '\f');
 
 	// Deduplicate
 	filePaths = [...new Set(filePaths.map(filePath => path.resolve(filePath)))];

--- a/test.js
+++ b/test.js
@@ -15,7 +15,7 @@ test('--regex', async t => {
 	t.is(fs.readFileSync(filePath, 'utf8'), 'foo foo foo');
 });
 
-test('--string', async t => {
+test('test new line', async t => {
 	const filePath = await tempWrite(',');
 	await execa('./cli.js', ['--string=,', '--replacement=\n', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), '\n');

--- a/test.js
+++ b/test.js
@@ -14,3 +14,10 @@ test('--regex', async t => {
 	await execa('./cli.js', ['--regex=\\bb.*?\\b', '--replacement=foo', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'foo foo foo');
 });
+
+test('--string', async t => {
+	const filePath = await tempWrite(',');
+	await execa('./cli.js', ['--string=,', '--replacement=\n', filePath]);
+	t.is(fs.readFileSync(filePath, 'utf8'), '\n');
+});
+

--- a/test.js
+++ b/test.js
@@ -19,11 +19,11 @@ test('newlines and tabs', async t => {
 	const filePath = await tempWrite('a,b,c');
 	await execa('./cli.js', ['--string=,', '--replacement=\\n', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'a\nb\nc');
-	
+
 	const filePath2 = await tempWrite('a,b,c');
 	await execa('./cli.js', ['--string=,', '--replacement=\\t', filePath2]);
 	t.is(fs.readFileSync(filePath2, 'utf8'), 'a\tb\tc');
-	
+
 	const filePath3 = await tempWrite('a,b,c');
 	await execa('./cli.js', ['--string=,', '--replacement=\\r', filePath3]);
 	t.is(fs.readFileSync(filePath3, 'utf8'), 'a\rb\rc');

--- a/test.js
+++ b/test.js
@@ -15,19 +15,21 @@ test('--regex', async t => {
 	t.is(fs.readFileSync(filePath, 'utf8'), 'foo foo foo');
 });
 
-test('new lines and tabs', async t => {
-	let filePath = await tempWrite('a,b,c');
+test('newlines and tabs', async t => {
+	const filePath = await tempWrite('a,b,c');
 	await execa('./cli.js', ['--string=,', '--replacement=\\n', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'a\nb\nc');
-	filePath = await tempWrite('a,b,c');
-	await execa('./cli.js', ['--string=,', '--replacement=\\t', filePath]);
-	t.is(fs.readFileSync(filePath, 'utf8'), 'a\tb\tc');
-	filePath = await tempWrite('a,b,c');
-	await execa('./cli.js', ['--string=,', '--replacement=\\r', filePath]);
-	t.is(fs.readFileSync(filePath, 'utf8'), 'a\rb\rc');
+	
+	const filePath2 = await tempWrite('a,b,c');
+	await execa('./cli.js', ['--string=,', '--replacement=\\t', filePath2]);
+	t.is(fs.readFileSync(filePath2, 'utf8'), 'a\tb\tc');
+	
+	const filePath3 = await tempWrite('a,b,c');
+	await execa('./cli.js', ['--string=,', '--replacement=\\r', filePath3]);
+	t.is(fs.readFileSync(filePath3, 'utf8'), 'a\rb\rc');
 });
 
-test('multiple new lines and tabs', async t => {
+test('multiple newlines and tabs', async t => {
 	const filePath = await tempWrite('a,b,c');
 	await execa('./cli.js', ['--string=,', '--replacement=\\n\\n\\t\\r', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'a\n\n\t\rb\n\n\t\rc');

--- a/test.js
+++ b/test.js
@@ -17,18 +17,18 @@ test('--regex', async t => {
 
 test('new lines and tabs', async t => {
 	let filePath = await tempWrite('a,b,c');
-	await execa('./cli.js', ['--string=,', '--replacement=\n', filePath]);
+	await execa('./cli.js', ['--string=,', '--replacement=\\n', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'a\nb\nc');
 	filePath = await tempWrite('a,b,c');
-	await execa('./cli.js', ['--string=,', '--replacement=\t', filePath]);
+	await execa('./cli.js', ['--string=,', '--replacement=\\t', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'a\tb\tc');
 	filePath = await tempWrite('a,b,c');
-	await execa('./cli.js', ['--string=,', '--replacement=\r', filePath]);
+	await execa('./cli.js', ['--string=,', '--replacement=\\r', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'a\rb\rc');
 });
 
 test('multiple new lines and tabs', async t => {
 	const filePath = await tempWrite('a,b,c');
-	await execa('./cli.js', ['--string=,', '--replacement=\n\n\t\r', filePath]);
+	await execa('./cli.js', ['--string=,', '--replacement=\\n\\n\\t\\r', filePath]);
 	t.is(fs.readFileSync(filePath, 'utf8'), 'a\n\n\t\rb\n\n\t\rc');
 });

--- a/test.js
+++ b/test.js
@@ -15,9 +15,20 @@ test('--regex', async t => {
 	t.is(fs.readFileSync(filePath, 'utf8'), 'foo foo foo');
 });
 
-test('test new line', async t => {
-	const filePath = await tempWrite(',');
+test('new lines and tabs', async t => {
+	let filePath = await tempWrite('a,b,c');
 	await execa('./cli.js', ['--string=,', '--replacement=\n', filePath]);
-	t.is(fs.readFileSync(filePath, 'utf8'), '\n');
+	t.is(fs.readFileSync(filePath, 'utf8'), 'a\nb\nc');
+	filePath = await tempWrite('a,b,c');
+	await execa('./cli.js', ['--string=,', '--replacement=\t', filePath]);
+	t.is(fs.readFileSync(filePath, 'utf8'), 'a\tb\tc');
+	filePath = await tempWrite('a,b,c');
+	await execa('./cli.js', ['--string=,', '--replacement=\r', filePath]);
+	t.is(fs.readFileSync(filePath, 'utf8'), 'a\rb\rc');
 });
 
+test('multiple new lines and tabs', async t => {
+	const filePath = await tempWrite('a,b,c');
+	await execa('./cli.js', ['--string=,', '--replacement=\n\n\t\r', filePath]);
+	t.is(fs.readFileSync(filePath, 'utf8'), 'a\n\n\t\rb\n\n\t\rc');
+});


### PR DESCRIPTION
Fixed the issue. The problem comes when the command is executed and the replacement parameter has a backslash. The string is being escaped when parsed and ends up as '\\\n', this way when it's written on the file it is written literally (\n instead of a new line). 
My solution is basically replacing the escaped string with the unescaped one.

Fixes #2