### PR TITLE
Fix Windows issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+  - windows
 language: node_js
 node_js:
   - '12'

--- a/api.js
+++ b/api.js
@@ -1,7 +1,10 @@
 'use strict';
+const isWinOS = /^win/i.test(process.platform);
+
 const {promisify} = require('util');
 const path = require('path');
 const fs = require('fs');
+const normalizePath = isWinOS ? require('normalize-path') : s => s;
 const writeFileAtomic = require('write-file-atomic');
 const escapeStringRegexp = require('escape-string-regexp');
 const arrify = require('arrify');
@@ -33,7 +36,7 @@ module.exports = async (filePaths, {find, replacement, ignoreCase, glob} = {}) =
 		.replace(/\\r/g, '\r')
 		.replace(/\\t/g, '\t');
 
-	filePaths = glob ? await globby(filePaths) : [...new Set(filePaths.map(filePath => path.resolve(filePath)))];
+	filePaths = glob ? await globby(filePaths.map(filePath => normalizePath(filePath))) : [...new Set(filePaths.map(filePath => normalizePath(path.resolve(filePath))))];
 
 	find = find.map(element => {
 		const iFlag = ignoreCase ? 'i' : '';

--- a/api.js
+++ b/api.js
@@ -1,10 +1,8 @@
 'use strict';
-const isWindowsOS = process.platform === 'win32';
-
 const {promisify} = require('util');
 const path = require('path');
 const fs = require('fs');
-const normalizePath = isWindowsOS ? require('normalize-path') : s => s;
+const normalizePath = process.platform === 'win32' ? require('normalize-path') : x => x;
 const writeFileAtomic = require('write-file-atomic');
 const escapeStringRegexp = require('escape-string-regexp');
 const arrify = require('arrify');

--- a/api.js
+++ b/api.js
@@ -34,6 +34,7 @@ module.exports = async (filePaths, {find, replacement, ignoreCase, glob} = {}) =
 		.replace(/\\r/g, '\r')
 		.replace(/\\t/g, '\t');
 
+	// TODO: Drop the `normalizePath` call when https://github.com/mrmlnc/fast-glob/issues/240 is fixed.
 	filePaths = glob ? await globby(filePaths.map(filePath => normalizePath(filePath))) : [...new Set(filePaths.map(filePath => normalizePath(path.resolve(filePath))))];
 
 	find = find.map(element => {

--- a/api.js
+++ b/api.js
@@ -1,10 +1,10 @@
 'use strict';
-const isWinOS = /^win/i.test(process.platform);
+const isWindowsOS = process.platform === 'win32';
 
 const {promisify} = require('util');
 const path = require('path');
 const fs = require('fs');
-const normalizePath = isWinOS ? require('normalize-path') : s => s;
+const normalizePath = isWindowsOS ? require('normalize-path') : s => s;
 const writeFileAtomic = require('write-file-atomic');
 const escapeStringRegexp = require('escape-string-regexp');
 const arrify = require('arrify');

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"escape-string-regexp": "^2.0.0",
 		"globby": "^10.0.1",
 		"meow": "^5.0.0",
+		"normalize-path": "^3.0.0",
 		"write-file-atomic": "^3.0.0"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import test from 'ava';
 import execa from 'execa';
@@ -39,9 +38,9 @@ test('multiple newlines and tabs', async t => {
 
 test('globs', async t => {
 	const filePaths = [await tempWrite('foo bar foo', 'a.glob'), await tempWrite('foo bar foo', 'b.glob')];
-	const tmpdir = os.tmpdir();
+	const dirnames = filePaths.map(filePath => path.dirname(filePath));
 
-	await execa('./cli.js', ['--string=bar', '--replacement=foo', path.join(tmpdir, '*', '*.glob')]);
+	await execa('./cli.js', ['--string=bar', '--replacement=foo', path.join(dirnames[0], '*.glob'), path.join(dirnames[1], '*.glob')]);
 	t.is(fs.readFileSync(filePaths[0], 'utf8'), 'foo foo foo');
 	t.is(fs.readFileSync(filePaths[1], 'utf8'), 'foo foo foo');
 });

--- a/test.js
+++ b/test.js
@@ -46,7 +46,8 @@ test('globs', async t => {
 });
 
 test('no globs', async t => {
-	const filePaths = [await tempWrite('foo bar foo', '*.glob'), await tempWrite('foo bar foo', 'foo.glob')];
+	const isWinOS = /^win/i.test(process.platform);
+	const filePaths = [await tempWrite('foo bar foo', isWinOS ? 'STAR.glob' : '*.glob'), await tempWrite('foo bar foo', 'foo.glob')];
 	const dirnames = filePaths.map(filePath => path.dirname(filePath));
 
 	await t.throwsAsync(

--- a/test.js
+++ b/test.js
@@ -46,8 +46,7 @@ test('globs', async t => {
 });
 
 test('no globs', async t => {
-	const isWindowsOS = process.platform === 'win32';
-	const filePaths = [await tempWrite('foo bar foo', isWindowsOS ? 'STAR.glob' : '*.glob'), await tempWrite('foo bar foo', 'foo.glob')];
+	const filePaths = [await tempWrite('foo bar foo', process.platform === 'win32' ? 'STAR.glob' : '*.glob'), await tempWrite('foo bar foo', 'foo.glob')];
 	const dirnames = filePaths.map(filePath => path.dirname(filePath));
 
 	await t.throwsAsync(

--- a/test.js
+++ b/test.js
@@ -46,8 +46,8 @@ test('globs', async t => {
 });
 
 test('no globs', async t => {
-	const isWinOS = /^win/i.test(process.platform);
-	const filePaths = [await tempWrite('foo bar foo', isWinOS ? 'STAR.glob' : '*.glob'), await tempWrite('foo bar foo', 'foo.glob')];
+	const isWindowsOS = process.platform === 'win32';
+	const filePaths = [await tempWrite('foo bar foo', isWindowsOS ? 'STAR.glob' : '*.glob'), await tempWrite('foo bar foo', 'foo.glob')];
 	const dirnames = filePaths.map(filePath => path.dirname(filePath));
 
 	await t.throwsAsync(


### PR DESCRIPTION
> fixes #6 

Several fixes here, separated by commit...

- corrected glob expressions supplied to `globby` (must be normalized to forward slashes, and so failed for windows)
- fixed a permissions issue for `tmpdir()` causing 'globs' test to fail on some machines
- fixed a missing `catch` for internal faults
- fixed 'no globs' test specifically for Windows (removed use of an "impossible" file)

It's based on my [AppVeyor PR](https://github.com/sindresorhus/replace-in-files-cli/pull/7) for testing, but that's easily removed if you want to go pure Travis CI.

I can rework and/or drop any of the commits, by your request.